### PR TITLE
Correct translation error in ts-infer-type-predicates article

### DIFF
--- a/articles/ts-infer-type-predicates.md
+++ b/articles/ts-infer-type-predicates.md
@@ -155,7 +155,7 @@ const result = [12, null, 24, undefined, 48]
                 .filter((value) => value != null);
 ```
 
-開発社は、`result`の型は`number[]`に推論されることを期待するでしょう。
+開発者は、`result`の型は`number[]`に推論されることを期待するでしょう。
 
 ## 従来の課題
 


### PR DESCRIPTION
An incorrect translation in the ts-infer-type-predicates.md document was detected and corrected. The word for 'developer' has been accurately translated from Japanese.