### PR TITLE
Clarify correct usage of `margin: 0 auto;`

### DIFF
--- a/articles/margin-inline_auto.md
+++ b/articles/margin-inline_auto.md
@@ -127,19 +127,18 @@ main section {
 
 - [別ウインドウで開く](https://codepen.io/tonkotsuboy/pen/OJBKBKx)
 
-
-# `margin: auto;` ではだめなのか？
+# `margin: 0 auto;` ではだめなのか？
 
 筆者的には避けたいです。
 
 `margin: auto;` は、次の指定のショートハンドです。
 
-- `margin-top: auto;`
+- `margin-top: 0;`
 - `margin-right: auto;`
-- `margin-bottom: auto;`
+- `margin-bottom: 0;`
 - `margin-left: auto;`
 
-インライン方向の中央揃えを指定したいだけなのに、`margin-top`と`margin-bottom`も指定してしまうと、予期せぬスタイルの上書きを考慮しないとなりません。
+インライン方向の中央揃えを指定したいだけなのに、`margin-top: 0;`と`margin-bottom: 0`も指定してしまうと、予期せぬスタイルの上書きを考慮しないとなりません。
 
 
 # `margin-inline`は書字方向によって変わることに注意


### PR DESCRIPTION
In this pull request, we have clarified the correct usage of `margin: 0 auto;` in the documentation to prevent unexpected style overrides for `margin-top` and `margin-bottom`, ensuring consistent layout styling.