### PR TITLE
パラメータプロパティの例がただの引数になっているのを修正

### DIFF
--- a/articles/ts-58-erasable-syntax-only.md
+++ b/articles/ts-58-erasable-syntax-only.md
@@ -40,7 +40,7 @@ namespace myNameSpace {
 }
 
 class MyClass {
-  constructor(myField: string) {}
+  constructor(private myField: string) {}
 }
 ```
 
@@ -139,9 +139,11 @@ console.log(myNameSpace.myName); // "とんこつ"
 
 ```ts
 class MyClass {
-  myField: string;
+  private myField: string;
 
-  constructor() {}
+  constructor(initialValue: string) {
+    this.myField = initialValue;
+  }
 }
 ```
 

--- a/articles/ts-58-erasable-syntax-only.md
+++ b/articles/ts-58-erasable-syntax-only.md
@@ -142,7 +142,7 @@ class MyClass {
   private myField: string;
 
   constructor(initialValue: string) {
-    this.myField = initialValue;
+    this.myField = "foo";
   }
 }
 ```


### PR DESCRIPTION
パラメータプロパティの例として掲載されているコードがスクリーンショットの物と違っていて、ただの引数になっていたのを`private`を追記して修正しました。

また、パラメータプロパティを使わない場合の例を、使う場合と同じ機能を維持できるように引数を追加し、フィールドには`private`修飾子を追加しました。

パラメータプロパティを使わない例のスクリーンショットの修正は行っていません。